### PR TITLE
kotlin.Resultを使用するように修正

### DIFF
--- a/TemplateApp01/.idea/androidTestResultsUserPreferences.xml
+++ b/TemplateApp01/.idea/androidTestResultsUserPreferences.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AndroidTestResultsUserPreferences">
+    <option name="androidTestResultsTableState">
+      <map>
+        <entry key="-2104299703">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Pixel_4_API_Tiramisu" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
+      </map>
+    </option>
+  </component>
+</project>

--- a/TemplateApp01/.idea/misc.xml
+++ b/TemplateApp01/.idea/misc.xml
@@ -94,6 +94,7 @@
         <entry key="../../../../../../layout/compose-model-1643197420638.xml" value="0.1" />
         <entry key="../../../../../../layout/compose-model-1643260648189.xml" value="0.1" />
         <entry key="../../../../../../layout/compose-model-1643260770810.xml" value="0.1" />
+        <entry key="../../../../../../layout/compose-model-1645023253994.xml" value="0.1" />
         <entry key="app/src/main/res/drawable/ic_launcher_foreground.xml" value="0.203" />
         <entry key="app/src/main/res/drawable/placeholder.xml" value="0.107" />
       </map>

--- a/TemplateApp01/app/src/main/java/com/example/templateapp01/data/Result.kt
+++ b/TemplateApp01/app/src/main/java/com/example/templateapp01/data/Result.kt
@@ -15,36 +15,36 @@ import java.net.UnknownHostException
  */
 internal sealed class SafeResult<out R> {
     data class Success<out T>(val data: T) : SafeResult<T>()
-    data class Error(val errorResult: ErrorResult) : SafeResult<Nothing>()
+    data class Failure(val failureResult: FailureResult) : SafeResult<Nothing>()
 }
 
-internal sealed class ErrorResult : Exception() {
-    data class UnAuthorizedError(override val message: String? = "UnAuthorizedError") :
-        ErrorResult()
+internal sealed class FailureResult : Exception() {
+    data class UnAuthorizedFailure(override val message: String? = "UnAuthorizedError") :
+        FailureResult()
 
-    data class BadRequestError(override val message: String? = "BadRequestError") :
-        ErrorResult()
+    data class BadRequestFailure(override val message: String? = "BadRequestError") :
+        FailureResult()
 
-    data class NotFoundError(override val message: String? = "NotFoundError") :
-        ErrorResult()
+    data class NotFoundFailure(override val message: String? = "NotFoundError") :
+        FailureResult()
 
-    data class NetworkError(override val message: String? = "NetworkError") :
-        ErrorResult()
+    data class NetworkFailure(override val message: String? = "NetworkError") :
+        FailureResult()
 
-    data class OtherError(override val message: String? = "OtherError") :
-        ErrorResult()
+    data class OtherFailure(override val message: String? = "OtherError") :
+        FailureResult()
 }
 
 internal inline fun <T> SafeResult<T>.fold(
     onSuccess: (value: T) -> Unit,
-    onFailure: (ErrorResult) -> Unit,
+    onFailure: (FailureResult) -> Unit,
 ): SafeResult<T> {
     val success = this as? SafeResult.Success
-    val failure = this as? SafeResult.Error
+    val failure = this as? SafeResult.Failure
     success?.let { onSuccess(success.data) }
     failure?.let {
-        onFailure(failure.errorResult)
-        Log.e("fold", "error: " + failure.errorResult.localizedMessage)
+        onFailure(failure.failureResult)
+        Log.e("fold", "error: " + failure.failureResult.localizedMessage)
     }
     return this
 }
@@ -63,29 +63,29 @@ internal suspend fun <T> safeCall(
                 is HttpException -> {
                     when (e.code()) {
                         HttpURLConnection.HTTP_UNAUTHORIZED -> {
-                            SafeResult.Error(
-                                ErrorResult.UnAuthorizedError(
+                            SafeResult.Failure(
+                                FailureResult.UnAuthorizedFailure(
                                     e.localizedMessage
                                 )
                             )
                         }
                         HttpURLConnection.HTTP_BAD_REQUEST -> {
-                            SafeResult.Error(
-                                ErrorResult.BadRequestError(
+                            SafeResult.Failure(
+                                FailureResult.BadRequestFailure(
                                     e.localizedMessage
                                 )
                             )
                         }
                         HttpURLConnection.HTTP_NOT_FOUND -> {
-                            SafeResult.Error(
-                                ErrorResult.NotFoundError(
+                            SafeResult.Failure(
+                                FailureResult.NotFoundFailure(
                                     e.localizedMessage
                                 )
                             )
                         }
                         else -> {
-                            SafeResult.Error(
-                                ErrorResult.OtherError(
+                            SafeResult.Failure(
+                                FailureResult.OtherFailure(
                                     e.localizedMessage
                                 )
                             )
@@ -93,15 +93,15 @@ internal suspend fun <T> safeCall(
                     }
                 }
                 is UnknownHostException, is ConnectException, is SocketTimeoutException -> {
-                    SafeResult.Error(
-                        ErrorResult.NetworkError(
+                    SafeResult.Failure(
+                        FailureResult.NetworkFailure(
                             e.localizedMessage
                         )
                     )
                 }
                 else -> {
-                    SafeResult.Error(
-                        ErrorResult.OtherError(
+                    SafeResult.Failure(
+                        FailureResult.OtherFailure(
                             e.localizedMessage
                         )
                     )

--- a/TemplateApp01/app/src/main/java/com/example/templateapp01/data/repository/impl/TodoRepositoryImpl.kt
+++ b/TemplateApp01/app/src/main/java/com/example/templateapp01/data/repository/impl/TodoRepositoryImpl.kt
@@ -1,6 +1,5 @@
 package com.example.templateapp01.data.repository.impl
 
-import com.example.templateapp01.data.SafeResult
 import com.example.templateapp01.domain.repository.TodoRepository
 import com.example.templateapp01.data.room.dao.TodoDao
 import com.example.templateapp01.data.room.entity.TodoEntity
@@ -36,7 +35,7 @@ internal class TodoRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun findTodoDataById(id: Int): SafeResult<TodoData> {
+    override suspend fun findTodoDataById(id: Int): Result<TodoData> {
         return safeCall(dispatcher) { todoDao.findTodoDataById(id).toTodoData() }
     }
 
@@ -63,18 +62,18 @@ internal class TodoRepositoryImpl @Inject constructor(
         return todoDao.findTodoListAsFlow().map { it.toTodoDataList() }.flowOn(Dispatchers.IO)
     }
 
-    override suspend fun getCompletedTodoList(): SafeResult<List<TodoData>> {
+    override suspend fun getCompletedTodoList(): Result<List<TodoData>> {
         return safeCall(dispatcher) { todoDao.findCompletedTodoList().toTodoDataList() }
     }
 
-    override suspend fun getInCompleteTodoList(): SafeResult<List<TodoData>> {
+    override suspend fun getInCompleteTodoList(): Result<List<TodoData>> {
         return safeCall(dispatcher) { todoDao.findInCompleteTodoList().toTodoDataList() }
     }
 
     override suspend fun getBetweenDatesTodoList(
         from: Date,
         to: Date
-    ): SafeResult<List<TodoData>> {
+    ): Result<List<TodoData>> {
         return safeCall(dispatcher) { todoDao.findBetweenDatesTodoList(from, to).toTodoDataList() }
     }
 }

--- a/TemplateApp01/app/src/main/java/com/example/templateapp01/data/repository/impl/UnsplashRepositoryImpl.kt
+++ b/TemplateApp01/app/src/main/java/com/example/templateapp01/data/repository/impl/UnsplashRepositoryImpl.kt
@@ -1,6 +1,5 @@
 package com.example.templateapp01.data.repository.impl
 
-import com.example.templateapp01.data.SafeResult
 import com.example.templateapp01.data.api.UnsplashService
 import com.example.templateapp01.domain.repository.UnsplashRepository
 import com.example.templateapp01.data.api.response.toModel
@@ -18,7 +17,7 @@ internal class UnsplashRepositoryImpl @Inject constructor(
         query: String,
         page: Int,
         perPage: Int
-    ): SafeResult<List<UnSplashPhoto>> {
+    ): Result<List<UnSplashPhoto>> {
         return safeCall(dispatcher) {
             api.searchPhotos(query, page, perPage).results.map { it.toModel() }
         }

--- a/TemplateApp01/app/src/main/java/com/example/templateapp01/domain/repository/TodoRepository.kt
+++ b/TemplateApp01/app/src/main/java/com/example/templateapp01/domain/repository/TodoRepository.kt
@@ -1,17 +1,16 @@
 package com.example.templateapp01.domain.repository
 
-import com.example.templateapp01.data.SafeResult
 import com.example.templateapp01.domain.model.TodoData
 import kotlinx.coroutines.flow.Flow
 import java.util.*
 
 internal interface TodoRepository {
     suspend fun addTodoData(vararg todoData: TodoData)
-    suspend fun findTodoDataById(id: Int): SafeResult<TodoData>
+    suspend fun findTodoDataById(id: Int): Result<TodoData>
     suspend fun deleteAllTodoItems()
     suspend fun updateTodoData(vararg todoData: TodoData)
     fun getTodoList(): Flow<List<TodoData>>
-    suspend fun getCompletedTodoList(): SafeResult<List<TodoData>>
-    suspend fun getInCompleteTodoList(): SafeResult<List<TodoData>>
-    suspend fun getBetweenDatesTodoList(from: Date, to: Date): SafeResult<List<TodoData>>
+    suspend fun getCompletedTodoList(): Result<List<TodoData>>
+    suspend fun getInCompleteTodoList(): Result<List<TodoData>>
+    suspend fun getBetweenDatesTodoList(from: Date, to: Date): Result<List<TodoData>>
 }

--- a/TemplateApp01/app/src/main/java/com/example/templateapp01/domain/repository/UnsplashRepository.kt
+++ b/TemplateApp01/app/src/main/java/com/example/templateapp01/domain/repository/UnsplashRepository.kt
@@ -1,6 +1,5 @@
 package com.example.templateapp01.domain.repository
 
-import com.example.templateapp01.data.SafeResult
 import com.example.templateapp01.domain.model.UnSplashPhoto
 
 internal interface UnsplashRepository {
@@ -8,5 +7,5 @@ internal interface UnsplashRepository {
         query: String,
         page: Int = 1,
         perPage: Int = 10
-    ): SafeResult<List<UnSplashPhoto>>
+    ): Result<List<UnSplashPhoto>>
 }

--- a/TemplateApp01/app/src/main/java/com/example/templateapp01/domain/usecase/SearchPhotosUseCase.kt
+++ b/TemplateApp01/app/src/main/java/com/example/templateapp01/domain/usecase/SearchPhotosUseCase.kt
@@ -1,6 +1,5 @@
 package com.example.templateapp01.domain.usecase
 
-import com.example.templateapp01.data.SafeResult
 import com.example.templateapp01.domain.repository.UnsplashRepository
 import com.example.templateapp01.di.DefaultDispatcher
 import com.example.templateapp01.domain.model.UnSplashPhoto
@@ -12,7 +11,7 @@ internal class SearchPhotosUseCase @Inject constructor(
     private val unsplashRepository: UnsplashRepository,
     @DefaultDispatcher private val dispatcher: CoroutineDispatcher
 ) {
-    suspend operator fun invoke(query: String): SafeResult<List<UnSplashPhoto>> {
+    suspend operator fun invoke(query: String): Result<List<UnSplashPhoto>> {
         return withContext(dispatcher) {
             unsplashRepository.searchPhotos(query)
         }

--- a/TemplateApp01/app/src/main/java/com/example/templateapp01/domain/usecase/TodoDoneUseCase.kt
+++ b/TemplateApp01/app/src/main/java/com/example/templateapp01/domain/usecase/TodoDoneUseCase.kt
@@ -1,6 +1,5 @@
 package com.example.templateapp01.domain.usecase
 
-import com.example.templateapp01.data.fold
 import com.example.templateapp01.domain.repository.TodoRepository
 import com.example.templateapp01.di.DefaultDispatcher
 import kotlinx.coroutines.CoroutineDispatcher

--- a/TemplateApp01/app/src/main/java/com/example/templateapp01/ui/favorite/FavoriteScreen.kt
+++ b/TemplateApp01/app/src/main/java/com/example/templateapp01/ui/favorite/FavoriteScreen.kt
@@ -141,7 +141,7 @@ internal fun TodoListContent(
             FavoriteUiState.Initial -> {
 
             }
-            is FavoriteUiState.Error -> {
+            is FavoriteUiState.Failure -> {
                 Text(text = uiState.errorMessage)
             }
             is FavoriteUiState.UpdateTodoList -> {
@@ -227,7 +227,7 @@ fun TodoListContent_Preview_UpdateTodoList() {
 fun TodoListContent_Preview_Error() {
     TemplateApp01Theme {
         TodoListContent(
-            uiState = FavoriteUiState.Error(errorMessage = "error!"),
+            uiState = FavoriteUiState.Failure(errorMessage = "error!"),
             onClickTodoItem = {},
         )
     }

--- a/TemplateApp01/app/src/main/java/com/example/templateapp01/ui/favorite/FavoriteUiState.kt
+++ b/TemplateApp01/app/src/main/java/com/example/templateapp01/ui/favorite/FavoriteUiState.kt
@@ -5,5 +5,5 @@ import com.example.templateapp01.domain.model.TodoData
 internal sealed interface FavoriteUiState {
     object Initial : FavoriteUiState
     data class UpdateTodoList(val todoList: List<TodoData>) : FavoriteUiState
-    data class Error(val errorMessage: String) : FavoriteUiState
+    data class Failure(val errorMessage: String) : FavoriteUiState
 }

--- a/TemplateApp01/app/src/main/java/com/example/templateapp01/ui/favorite/FavoriteViewModel.kt
+++ b/TemplateApp01/app/src/main/java/com/example/templateapp01/ui/favorite/FavoriteViewModel.kt
@@ -26,7 +26,7 @@ internal class FavoriteViewModel @Inject constructor(
         Log.d(LOG_TAG, "init: " + hashCode())
         viewModelScope.launch(CoroutineExceptionHandler { _, throwable ->
             // Failure
-            uiState = FavoriteUiState.Error(throwable.localizedMessage ?: "error!")
+            uiState = FavoriteUiState.Failure(throwable.localizedMessage ?: "error!")
         }) {
             todoRepository.getTodoList().collect {
                 uiState = FavoriteUiState.UpdateTodoList(it)

--- a/TemplateApp01/app/src/main/java/com/example/templateapp01/ui/home/HomeScreen.kt
+++ b/TemplateApp01/app/src/main/java/com/example/templateapp01/ui/home/HomeScreen.kt
@@ -44,9 +44,9 @@ internal fun HomeContent(
         modifier = modifier,
     ) {
         when (uiState) {
-            is HomeUiState.Error -> {
+            is HomeUiState.Failure -> {
                 ErrorMessage(
-                    message = "fetch error: ${uiState.error.message}",
+                    message = "fetch error: ${uiState.error.localizedMessage}",
                     onClickReload = onClickReload,
                     modifier = Modifier
                         .fillMaxSize()
@@ -114,7 +114,7 @@ fun HomeContent_Preview_Loading() {
 fun HomeContent_Preview_Error() {
     TemplateApp01Theme {
         HomeContent(
-            uiState = HomeUiState.Error(error = FailureResult.NetworkFailure("error error...")),
+            uiState = HomeUiState.Failure(error = FailureResult.Network("error error...")),
             onClickReload = { },
             onClickPhotoItem = {},
             modifier = Modifier.mainContentPadding(PaddingValues(12.dp, 12.dp, 12.dp, 92.dp))

--- a/TemplateApp01/app/src/main/java/com/example/templateapp01/ui/home/HomeScreen.kt
+++ b/TemplateApp01/app/src/main/java/com/example/templateapp01/ui/home/HomeScreen.kt
@@ -11,7 +11,7 @@ import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import com.example.templateapp01.data.ErrorResult
+import com.example.templateapp01.data.FailureResult
 import com.example.templateapp01.ui.components.*
 import com.example.templateapp01.ui.components.FullScreenLoading
 import com.example.templateapp01.ui.extentions.mainContentPadding
@@ -114,7 +114,7 @@ fun HomeContent_Preview_Loading() {
 fun HomeContent_Preview_Error() {
     TemplateApp01Theme {
         HomeContent(
-            uiState = HomeUiState.Error(error = ErrorResult.NetworkError("error error...")),
+            uiState = HomeUiState.Error(error = FailureResult.NetworkFailure("error error...")),
             onClickReload = { },
             onClickPhotoItem = {},
             modifier = Modifier.mainContentPadding(PaddingValues(12.dp, 12.dp, 12.dp, 92.dp))

--- a/TemplateApp01/app/src/main/java/com/example/templateapp01/ui/home/HomeUiState.kt
+++ b/TemplateApp01/app/src/main/java/com/example/templateapp01/ui/home/HomeUiState.kt
@@ -1,6 +1,5 @@
 package com.example.templateapp01.ui.home
 
-import com.example.templateapp01.data.FailureResult
 import com.example.templateapp01.domain.model.UnSplashPhoto
 
 internal sealed interface HomeUiState {
@@ -8,5 +7,5 @@ internal sealed interface HomeUiState {
     object NoPhotos : HomeUiState
     data class Photos(val results: List<UnSplashPhoto> = emptyList()) : HomeUiState
     object Loading : HomeUiState
-    data class Error(val error: FailureResult) : HomeUiState
+    data class Failure(val error: Throwable) : HomeUiState
 }

--- a/TemplateApp01/app/src/main/java/com/example/templateapp01/ui/home/HomeUiState.kt
+++ b/TemplateApp01/app/src/main/java/com/example/templateapp01/ui/home/HomeUiState.kt
@@ -1,6 +1,6 @@
 package com.example.templateapp01.ui.home
 
-import com.example.templateapp01.data.ErrorResult
+import com.example.templateapp01.data.FailureResult
 import com.example.templateapp01.domain.model.UnSplashPhoto
 
 internal sealed interface HomeUiState {
@@ -8,5 +8,5 @@ internal sealed interface HomeUiState {
     object NoPhotos : HomeUiState
     data class Photos(val results: List<UnSplashPhoto> = emptyList()) : HomeUiState
     object Loading : HomeUiState
-    data class Error(val error: ErrorResult) : HomeUiState
+    data class Error(val error: FailureResult) : HomeUiState
 }

--- a/TemplateApp01/app/src/main/java/com/example/templateapp01/ui/home/HomeViewModel.kt
+++ b/TemplateApp01/app/src/main/java/com/example/templateapp01/ui/home/HomeViewModel.kt
@@ -4,7 +4,7 @@ import android.util.Log
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.example.templateapp01.data.ErrorResult
+import com.example.templateapp01.data.FailureResult
 import com.example.templateapp01.data.SafeResult
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
@@ -38,11 +38,11 @@ internal class HomeViewModel @Inject constructor(
                         HomeUiState.Photos(results = ret.data) // stop loading.
                     }
                 }
-                is SafeResult.Error -> {
-                    when (ret.errorResult) {
-                        is ErrorResult.BadRequestError, is ErrorResult.NetworkError,
-                        is ErrorResult.NotFoundError, is ErrorResult.OtherError, is ErrorResult.UnAuthorizedError -> {
-                            uiState = HomeUiState.Error(ret.errorResult) // stop loading.
+                is SafeResult.Failure -> {
+                    when (ret.failureResult) {
+                        is FailureResult.BadRequestFailure, is FailureResult.NetworkFailure,
+                        is FailureResult.NotFoundFailure, is FailureResult.OtherFailure, is FailureResult.UnAuthorizedFailure -> {
+                            uiState = HomeUiState.Error(ret.failureResult) // stop loading.
                         }
                     }
                 }

--- a/TemplateApp01/app/src/main/java/com/example/templateapp01/ui/search/ResultScreen.kt
+++ b/TemplateApp01/app/src/main/java/com/example/templateapp01/ui/search/ResultScreen.kt
@@ -106,15 +106,15 @@ internal fun ResultContent(
                             .size(120.dp)
                     )
                 }
-                is SearchResultUiState.Error -> {
+                is SearchResultUiState.Failure -> {
                     ErrorMessage(
-                        message = "fetch error." + uiState.result.message,
+                        message = "fetch error." + uiState.throwable.localizedMessage,
                         onClickReload = onClickReload,
                         modifier = Modifier
                             .fillMaxSize()
                             .wrapContentSize()
                     )
-                    onError(uiState.result.message ?: "error.")
+                    onError(uiState.throwable.localizedMessage ?: "error.")
                 }
             }
             Spacer(modifier = Modifier.height(20.dp))
@@ -228,7 +228,7 @@ fun ResultContent_Preview_Loading() {
 fun ResultContent_Preview_Error() {
     TemplateApp01Theme {
         ResultContent(
-            uiState = SearchResultUiState.Error(result = FailureResult.NetworkFailure("error error error")),
+            uiState = SearchResultUiState.Failure(throwable = FailureResult.Network("error error error")),
             navController = rememberNavController(),
             onClickReload = {},
             modifier = Modifier.mainContentPadding(PaddingValues(12.dp, 12.dp, 12.dp, 92.dp)),

--- a/TemplateApp01/app/src/main/java/com/example/templateapp01/ui/search/ResultScreen.kt
+++ b/TemplateApp01/app/src/main/java/com/example/templateapp01/ui/search/ResultScreen.kt
@@ -17,7 +17,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
-import com.example.templateapp01.data.ErrorResult
+import com.example.templateapp01.data.FailureResult
 import com.example.templateapp01.domain.model.UnSplashPhoto
 import com.example.templateapp01.ui.components.*
 import com.example.templateapp01.ui.components.FullScreenLoading
@@ -228,7 +228,7 @@ fun ResultContent_Preview_Loading() {
 fun ResultContent_Preview_Error() {
     TemplateApp01Theme {
         ResultContent(
-            uiState = SearchResultUiState.Error(result = ErrorResult.NetworkError("error error error")),
+            uiState = SearchResultUiState.Error(result = FailureResult.NetworkFailure("error error error")),
             navController = rememberNavController(),
             onClickReload = {},
             modifier = Modifier.mainContentPadding(PaddingValues(12.dp, 12.dp, 12.dp, 92.dp)),

--- a/TemplateApp01/app/src/main/java/com/example/templateapp01/ui/search/SearchResultUiState.kt
+++ b/TemplateApp01/app/src/main/java/com/example/templateapp01/ui/search/SearchResultUiState.kt
@@ -1,6 +1,6 @@
 package com.example.templateapp01.ui.search
 
-import com.example.templateapp01.data.ErrorResult
+import com.example.templateapp01.data.FailureResult
 import com.example.templateapp01.domain.model.UnSplashPhoto
 
 internal sealed interface SearchResultUiState {
@@ -9,5 +9,5 @@ internal sealed interface SearchResultUiState {
     object NoPhotos : SearchResultUiState
     data class Photos(val results: List<UnSplashPhoto> = emptyList()) : SearchResultUiState
     object Loading : SearchResultUiState
-    data class Error(val result: ErrorResult) : SearchResultUiState
+    data class Error(val result: FailureResult) : SearchResultUiState
 }

--- a/TemplateApp01/app/src/main/java/com/example/templateapp01/ui/search/SearchResultUiState.kt
+++ b/TemplateApp01/app/src/main/java/com/example/templateapp01/ui/search/SearchResultUiState.kt
@@ -1,6 +1,5 @@
 package com.example.templateapp01.ui.search
 
-import com.example.templateapp01.data.FailureResult
 import com.example.templateapp01.domain.model.UnSplashPhoto
 
 internal sealed interface SearchResultUiState {
@@ -9,5 +8,5 @@ internal sealed interface SearchResultUiState {
     object NoPhotos : SearchResultUiState
     data class Photos(val results: List<UnSplashPhoto> = emptyList()) : SearchResultUiState
     object Loading : SearchResultUiState
-    data class Error(val result: FailureResult) : SearchResultUiState
+    data class Failure(val throwable: Throwable) : SearchResultUiState
 }

--- a/TemplateApp01/app/src/main/java/com/example/templateapp01/ui/search/SearchResultViewModel.kt
+++ b/TemplateApp01/app/src/main/java/com/example/templateapp01/ui/search/SearchResultViewModel.kt
@@ -6,7 +6,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.example.templateapp01.data.ErrorResult
+import com.example.templateapp01.data.FailureResult
 import com.example.templateapp01.data.SafeResult
 import com.example.templateapp01.domain.repository.UnsplashRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -39,11 +39,11 @@ internal class SearchResultViewModel @Inject constructor(
                         SearchResultUiState.Photos(results = ret.data)
                     }
                 }
-                is SafeResult.Error -> {
-                    when (ret.errorResult) {
-                        is ErrorResult.BadRequestError, is ErrorResult.NetworkError,
-                        is ErrorResult.NotFoundError, is ErrorResult.OtherError, is ErrorResult.UnAuthorizedError -> {
-                            uiState = SearchResultUiState.Error(ret.errorResult) // stop loading.
+                is SafeResult.Failure -> {
+                    when (ret.failureResult) {
+                        is FailureResult.BadRequestFailure, is FailureResult.NetworkFailure,
+                        is FailureResult.NotFoundFailure, is FailureResult.OtherFailure, is FailureResult.UnAuthorizedFailure -> {
+                            uiState = SearchResultUiState.Error(ret.failureResult) // stop loading.
                         }
                     }
                 }

--- a/TemplateApp01/app/src/test/java/com/example/templateapp01/domain/usecase/SearchPhotosUseCaseTest.kt
+++ b/TemplateApp01/app/src/test/java/com/example/templateapp01/domain/usecase/SearchPhotosUseCaseTest.kt
@@ -1,7 +1,7 @@
 package com.example.templateapp01.domain.usecase
 
 import com.example.templateapp01.CoroutinesTestRule
-import com.example.templateapp01.data.ErrorResult
+import com.example.templateapp01.data.FailureResult
 import com.example.templateapp01.data.SafeResult
 import com.example.templateapp01.domain.repository.UnsplashRepository
 import com.example.templateapp01.domain.model.UnSplashPhoto
@@ -59,7 +59,7 @@ class SearchPhotosUseCaseTest {
             }
             doReturn(retValue).whenever(unsplashRepository).searchPhotos(query = "dogs")
             when (searchPhotosUseCase(query = "dogs")) {
-                is SafeResult.Error -> assert(false)
+                is SafeResult.Failure -> assert(false)
                 is SafeResult.Success -> assert(true)
             }
         }
@@ -74,7 +74,7 @@ class SearchPhotosUseCaseTest {
 
             searchPhotosUseCase(query = "dogs")
             when (val ret = searchPhotosUseCase(query = "dogs")) {
-                is SafeResult.Error -> assert(false)
+                is SafeResult.Failure -> assert(false)
                 is SafeResult.Success -> {
                     assert(ret.data.isEmpty())
                 }
@@ -86,13 +86,13 @@ class SearchPhotosUseCaseTest {
     fun `failure search Photos`() {
         coroutinesTestRule.testDispatcher.runBlockingTest {
 
-            val retValue = SafeResult.Error(ErrorResult.NetworkError("error!"))
+            val retValue = SafeResult.Failure(FailureResult.NetworkFailure("error!"))
 
             doReturn(retValue).whenever(unsplashRepository).searchPhotos(query = "dogs")
 
             searchPhotosUseCase(query = "dogs")
             when (searchPhotosUseCase(query = "dogs")) {
-                is SafeResult.Error -> assert(true)
+                is SafeResult.Failure -> assert(true)
                 is SafeResult.Success -> assert(false)
             }
         }

--- a/TemplateApp01/app/src/test/java/com/example/templateapp01/ui/home/HomeViewModelTest.kt
+++ b/TemplateApp01/app/src/test/java/com/example/templateapp01/ui/home/HomeViewModelTest.kt
@@ -1,7 +1,7 @@
 package com.example.templateapp01.ui.home
 
 import com.example.templateapp01.CoroutinesTestRule
-import com.example.templateapp01.data.ErrorResult
+import com.example.templateapp01.data.FailureResult
 import com.example.templateapp01.data.SafeResult
 import com.example.templateapp01.domain.repository.UnsplashRepository
 import com.example.templateapp01.domain.model.UnSplashPhoto
@@ -77,7 +77,7 @@ class HomeViewModelTest {
     fun `failure search Photos`() {
         coroutinesTestRule.testDispatcher.runBlockingTest {
 
-            val retValue = SafeResult.Error(ErrorResult.NetworkError("error!"))
+            val retValue = SafeResult.Failure(FailureResult.NetworkFailure("error!"))
 
             doReturn(retValue).whenever(unsplashRepository).searchPhotos(query = "dogs")
 

--- a/TemplateApp01/app/src/test/java/com/example/templateapp01/ui/home/HomeViewModelTest.kt
+++ b/TemplateApp01/app/src/test/java/com/example/templateapp01/ui/home/HomeViewModelTest.kt
@@ -2,7 +2,6 @@ package com.example.templateapp01.ui.home
 
 import com.example.templateapp01.CoroutinesTestRule
 import com.example.templateapp01.data.FailureResult
-import com.example.templateapp01.data.SafeResult
 import com.example.templateapp01.domain.repository.UnsplashRepository
 import com.example.templateapp01.domain.model.UnSplashPhoto
 import com.nhaarman.mockitokotlin2.*
@@ -37,7 +36,7 @@ class HomeViewModelTest {
     fun `successful search Photos`() {
         coroutinesTestRule.testDispatcher.runBlockingTest {
 
-            val retValue: SafeResult<List<UnSplashPhoto>> = buildList {
+            val retValue: Result<List<UnSplashPhoto>> = buildList {
                 repeat(3) { id ->
                     add(
                         UnSplashPhoto(
@@ -52,7 +51,7 @@ class HomeViewModelTest {
                     )
                 }
             }.let {
-                SafeResult.Success(it)
+                Result.success(it)
             }
             doReturn(retValue).whenever(unsplashRepository).searchPhotos(query = "dogs")
 
@@ -65,7 +64,7 @@ class HomeViewModelTest {
     fun `empty search Photos`() {
         coroutinesTestRule.testDispatcher.runBlockingTest {
 
-            val retValue: SafeResult<List<UnSplashPhoto>> = SafeResult.Success(emptyList())
+            val retValue: Result<List<UnSplashPhoto>> = Result.success(emptyList())
             doReturn(retValue).whenever(unsplashRepository).searchPhotos(query = "dogs")
 
             homeViewModel.searchPhotos()
@@ -77,12 +76,12 @@ class HomeViewModelTest {
     fun `failure search Photos`() {
         coroutinesTestRule.testDispatcher.runBlockingTest {
 
-            val retValue = SafeResult.Failure(FailureResult.NetworkFailure("error!"))
+            val retValue = Result.failure<FailureResult>(FailureResult.Network("error!"))
 
             doReturn(retValue).whenever(unsplashRepository).searchPhotos(query = "dogs")
 
             homeViewModel.searchPhotos()
-            assert(homeViewModel.uiState is HomeUiState.Error)
+            assert(homeViewModel.uiState is HomeUiState.Failure)
         }
     }
 }

--- a/TemplateApp01/app/src/test/java/com/example/templateapp01/ui/search/SearchResultViewModelTest.kt
+++ b/TemplateApp01/app/src/test/java/com/example/templateapp01/ui/search/SearchResultViewModelTest.kt
@@ -2,7 +2,6 @@ package com.example.templateapp01.ui.search
 
 import com.example.templateapp01.CoroutinesTestRule
 import com.example.templateapp01.data.FailureResult
-import com.example.templateapp01.data.SafeResult
 import com.example.templateapp01.domain.repository.UnsplashRepository
 import com.example.templateapp01.domain.model.UnSplashPhoto
 import com.nhaarman.mockitokotlin2.doReturn
@@ -38,7 +37,7 @@ class SearchResultViewModelTest {
     fun `successful search Photos`() {
         coroutinesTestRule.testDispatcher.runBlockingTest {
 
-            val retValue: SafeResult<List<UnSplashPhoto>> = buildList {
+            val retValue: Result<List<UnSplashPhoto>> = buildList {
                 repeat(3) { id ->
                     add(
                         UnSplashPhoto(
@@ -53,7 +52,7 @@ class SearchResultViewModelTest {
                     )
                 }
             }.let {
-                SafeResult.Success(it)
+                Result.success(it)
             }
             doReturn(retValue).whenever(unsplashRepository).searchPhotos(query = "dogs")
 
@@ -66,7 +65,7 @@ class SearchResultViewModelTest {
     fun `empty search Photos`() {
         coroutinesTestRule.testDispatcher.runBlockingTest {
 
-            val retValue: SafeResult<List<UnSplashPhoto>> = SafeResult.Success(emptyList())
+            val retValue: Result<List<UnSplashPhoto>> = Result.success(emptyList())
             doReturn(retValue).whenever(unsplashRepository).searchPhotos(query = "dogs")
 
             searchResultViewModel.searchPhotos(query = "dogs")
@@ -78,12 +77,12 @@ class SearchResultViewModelTest {
     fun `failure search Photos`() {
         coroutinesTestRule.testDispatcher.runBlockingTest {
 
-            val retValue = SafeResult.Failure(FailureResult.NetworkFailure("error!"))
+            val retValue = Result.failure<FailureResult>(FailureResult.Network("error!"))
 
             doReturn(retValue).whenever(unsplashRepository).searchPhotos(query = "dogs")
 
             searchResultViewModel.searchPhotos(query = "dogs")
-            assert(searchResultViewModel.uiState is SearchResultUiState.Error)
+            assert(searchResultViewModel.uiState is SearchResultUiState.Failure)
         }
     }
 }

--- a/TemplateApp01/app/src/test/java/com/example/templateapp01/ui/search/SearchResultViewModelTest.kt
+++ b/TemplateApp01/app/src/test/java/com/example/templateapp01/ui/search/SearchResultViewModelTest.kt
@@ -1,7 +1,7 @@
 package com.example.templateapp01.ui.search
 
 import com.example.templateapp01.CoroutinesTestRule
-import com.example.templateapp01.data.ErrorResult
+import com.example.templateapp01.data.FailureResult
 import com.example.templateapp01.data.SafeResult
 import com.example.templateapp01.domain.repository.UnsplashRepository
 import com.example.templateapp01.domain.model.UnSplashPhoto
@@ -78,7 +78,7 @@ class SearchResultViewModelTest {
     fun `failure search Photos`() {
         coroutinesTestRule.testDispatcher.runBlockingTest {
 
-            val retValue = SafeResult.Error(ErrorResult.NetworkError("error!"))
+            val retValue = SafeResult.Failure(FailureResult.NetworkFailure("error!"))
 
             doReturn(retValue).whenever(unsplashRepository).searchPhotos(query = "dogs")
 


### PR DESCRIPTION
kotlin.Resultを使用するとmockk を使用したjunitテストで、
https://github.com/mockk/mockk/issues/485#issue-694044181 と同じエラーが発生した。
以下のコメントに言語レベルのバグと記載されていた。
https://github.com/mockk/mockk/issues/485#issuecomment-872752453
https://youtrack.jetbrains.com/issue/KT-46477#focus=Comments-27-4952485.0-0

junit エラーログ
```
class kotlin.Result cannot be cast to class java.util.List (kotlin.Result is in unnamed module of loader 'app'; java.util.List is in module java.base of loader 'bootstrap')
java.lang.ClassCastException: class kotlin.Result cannot be cast to class java.util.List (kotlin.Result is in unnamed module of loader 'app'; java.util.List is in module java.base of loader 'bootstrap')
	at com.example.templateapp01.domain.usecase.SearchPhotosUseCaseTest$successful search Photos$1.invokeSuspend(SearchPhotosUseCaseTest.kt:61)
	at com.example.templateapp01.domain.usecase.SearchPhotosUseCaseTest$successful search Photos$1.invoke(SearchPhotosUseCaseTest.kt)
	at com.example.templateapp01.domain.usecase.SearchPhotosUseCaseTest$successful search Photos$1.invoke(SearchPhotosUseCaseTest.kt)
	at kotlinx.coroutines.test.TestBuildersKt$runBlockingTest$deferred$1.invokeSuspend(TestBuilders.kt:50)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
	at kotlinx.coroutines.test.TestCoroutineDispatcher.dispatch(TestCoroutineDispatcher.kt:50)
	at kotlinx.coroutines.internal.DispatchedContinuationKt.resumeCancellableWith(DispatchedContinuation.kt:322)
	at kotlinx.coroutines.intrinsics.CancellableKt.startCoroutineCancellable(Cancellable.kt:30)
	at kotlinx.coroutines.intrinsics.CancellableKt.startCoroutineCancellable$default(Cancellable.kt:25)
	at kotlinx.coroutines.CoroutineStart.invoke(CoroutineStart.kt:110)
	at kotlinx.coroutines.AbstractCoroutine.start(AbstractCoroutine.kt:126)
	at kotlinx.coroutines.BuildersKt__Builders_commonKt.async(Builders.common.kt:91)
	at kotlinx.coroutines.BuildersKt.async(Unknown Source)
	at kotlinx.coroutines.BuildersKt__Builders_commonKt.async$default(Builders.common.kt:82)
	at kotlinx.coroutines.BuildersKt.async$default(Unknown Source)
	at kotlinx.coroutines.test.TestBuildersKt.runBlockingTest(TestBuilders.kt:49)
	at kotlinx.coroutines.test.TestBuildersKt.runBlockingTest(TestBuilders.kt:80)
	at com.example.templateapp01.domain.usecase.SearchPhotosUseCaseTest.successful search Photos(SearchPhotosUseCaseTest.kt:41)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.rules.TestWatcher$1.evaluate(TestWatcher.java:61)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
	at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
	at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
	at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.runTestClass(JUnitTestClassExecutor.java:110)
	at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.execute(JUnitTestClassExecutor.java:58)
	at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.execute(JUnitTestClassExecutor.java:38)
	at org.gradle.api.internal.tasks.testing.junit.AbstractJUnitTestClassProcessor.processTestClass(AbstractJUnitTestClassProcessor.java:62)
	at org.gradle.api.internal.tasks.testing.SuiteTestClassProcessor.processTestClass(SuiteTestClassProcessor.java:51)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:36)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
	at org.gradle.internal.dispatch.ContextClassLoaderDispatch.dispatch(ContextClassLoaderDispatch.java:33)
	at org.gradle.internal.dispatch.ProxyDispatchAdapter$DispatchingInvocationHandler.invoke(ProxyDispatchAdapter.java:94)
	at com.sun.proxy.$Proxy2.processTestClass(Unknown Source)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker$2.run(TestWorker.java:176)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.executeAndMaintainThreadName(TestWorker.java:129)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:100)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:60)
	at org.gradle.process.internal.worker.child.ActionExecutionWorker.execute(ActionExecutionWorker.java:56)
	at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:133)
	at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:71)
	at worker.org.gradle.process.internal.worker.GradleWorkerMain.run(GradleWorkerMain.java:69)
	at worker.org.gradle.process.internal.worker.GradleWorkerMain.main(GradleWorkerMain.java:74)


```